### PR TITLE
Interact with activities by day

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,15 +18,26 @@
 // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
-import {Socket} from "phoenix"
-import {LiveSocket} from "phoenix_live_view"
+import { Socket } from "phoenix"
+import { LiveSocket } from "phoenix_live_view"
 import topbar from "../vendor/topbar"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {
+  params: { _csrf_token: csrfToken },
+  metadata: {
+    click: (e, el) => {
+      const date = new Date();
+      return {
+        current_time: date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false }),
+        time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }
+    }
+  }
+})
 
 // Show progress bar on live navigation and form submits
-topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 

--- a/lib/recordid/activities.ex
+++ b/lib/recordid/activities.ex
@@ -22,6 +22,24 @@ defmodule Recordid.Activities do
   end
 
   @doc """
+  Returns a list of activities for a given date sorted by start time descending.
+  """
+  def list_activities_for_date(date) do
+    Activity
+    |> started_on(date)
+    |> most_recent_first()
+    |> Repo.all()
+  end
+
+  defp started_on(query, date) do
+    from a in query, where: a.date_started == ^date
+  end
+
+  defp most_recent_first(query) do
+    from a in query, order_by: [desc: a.date_started, desc: a.time_started]
+  end
+
+  @doc """
   Gets a single activity.
 
   Raises `Ecto.NoResultsError` if the Activity does not exist.
@@ -100,5 +118,9 @@ defmodule Recordid.Activities do
   """
   def change_activity(%Activity{} = activity, attrs \\ %{}) do
     Activity.changeset(activity, attrs)
+  end
+
+  def new_activity() do
+    %Activity{}
   end
 end

--- a/lib/recordid/activities/duration.ex
+++ b/lib/recordid/activities/duration.ex
@@ -1,0 +1,70 @@
+defmodule Recordid.Activities.Duration do
+  defstruct days: 0, hours: 0, minutes: 0
+
+  @seconds_in_day 24 * 60 * 60
+  @seconds_in_hour 60 * 60
+  @seconds_in_minute 60
+
+  def from_activity(%{date_started: ds, date_finished: df, time_started: ts, time_finished: tf})
+      when is_nil(ds) or is_nil(df) or is_nil(ts) or is_nil(tf) do
+    {:error, %__MODULE__{}}
+  end
+
+  def from_activity(activity) do
+    with {:ok, datetime_started} <- DateTime.new(activity.date_started, activity.time_started),
+         {:ok, datetime_finished} <- DateTime.new(activity.date_finished, activity.time_finished),
+         diff_in_seconds <- DateTime.diff(datetime_finished, datetime_started) do
+      {:ok,
+       %__MODULE__{}
+       |> put_days(diff_in_seconds)
+       |> put_hours(diff_in_seconds)
+       |> put_minutes(diff_in_seconds)}
+    else
+      _ -> {:error, %__MODULE__{}}
+    end
+  end
+
+  def to_string(%__MODULE__{} = duration) do
+    [:days, :hours, :minutes]
+    |> Enum.map(&field_to_string(&1, duration))
+    |> Enum.join(" ")
+    |> String.trim()
+  end
+
+  defp field_to_string(field, duration) do
+    case Map.get(duration, field) do
+      value when value in [0, nil] -> ""
+      value -> "#{value}#{field_abbreviation(field)}"
+    end
+  end
+
+  defp field_abbreviation(field) do
+    field
+    |> Atom.to_string()
+    |> String.first()
+  end
+
+  defp put_days(duration, seconds) do
+    days = div(seconds, @seconds_in_day)
+    %{duration | days: days}
+  end
+
+  defp put_hours(duration, seconds) do
+    hours =
+      seconds
+      |> rem(@seconds_in_day)
+      |> div(@seconds_in_hour)
+
+    %{duration | hours: hours}
+  end
+
+  defp put_minutes(duration, seconds) do
+    minutes =
+      seconds
+      |> rem(@seconds_in_day)
+      |> rem(@seconds_in_hour)
+      |> div(@seconds_in_minute)
+
+    %{duration | minutes: minutes}
+  end
+end

--- a/lib/recordid_web/components/activity_components.ex
+++ b/lib/recordid_web/components/activity_components.ex
@@ -1,0 +1,47 @@
+defmodule RecordidWeb.ActivityComponents do
+  use Phoenix.Component
+  alias Recordid.Activities.Activity
+  alias Recordid.Activities.Duration
+
+  attr :started_at, Time, required: false, default: nil
+  attr :finished_at, Time, required: false, default: nil
+
+  def time_range(%{started_at: nil, finished_at: nil} = assigns) do
+    ~H"""
+    <span></span>
+    """
+  end
+
+  def time_range(assigns) do
+    ~H"""
+    <div>
+      <span><%= format_time(@started_at) %></span><span>&ndash;</span><span><%= format_time(@finished_at) %></span>
+    </div>
+    """
+  end
+
+  attr :activity, Activity, required: true
+
+  def time_duration(assigns) do
+    ~H"""
+    <span class="text-xs font-semibold text-slate-400"><%= activity_duration(@activity) %></span>
+    """
+  end
+
+  defp activity_duration(activity) do
+    case Duration.from_activity(activity) do
+      {:ok, duration} -> Duration.to_string(duration)
+      _ -> ""
+    end
+  end
+
+  defp format_time(nil) do
+    ""
+  end
+
+  defp format_time(%Time{} = time) do
+    time
+    |> Time.to_string()
+    |> binary_slice(0, 5)
+  end
+end

--- a/lib/recordid_web/components/core_components.ex
+++ b/lib/recordid_web/components/core_components.ex
@@ -66,7 +66,7 @@ defmodule RecordidWeb.CoreComponents do
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
               phx-key="escape"
               phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
-              class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-2xl bg-white p-14 shadow-lg ring-1 transition"
+              class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-lg bg-white p-4 shadow-lg ring-6 transition"
             >
               <div class="absolute top-6 right-5">
                 <button
@@ -196,9 +196,9 @@ defmodule RecordidWeb.CoreComponents do
   def simple_form(assigns) do
     ~H"""
     <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="mt-10 space-y-8 bg-white">
+      <div class="mt-2 space-y-2 bg-white">
         <%= render_slot(@inner_block, f) %>
-        <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
+        <div :for={action <- @actions} class="mt-2 flex flex-row-reverse items-center justify-between gap-6">
           <%= render_slot(action, f) %>
         </div>
       </div>

--- a/lib/recordid_web/components/layouts/app.html.heex
+++ b/lib/recordid_web/components/layouts/app.html.heex
@@ -24,7 +24,7 @@
     </div>
   </div>
 </header>
-<main class="px-4 py-20 sm:px-6 lg:px-8">
+<main class="px-4 py-6 sm:px-6 lg:px-8 lg:py-20">
   <div class="mx-auto max-w-2xl">
     <.flash_group flash={@flash} />
     <%= @inner_content %>

--- a/lib/recordid_web/live/day_activity_live.ex
+++ b/lib/recordid_web/live/day_activity_live.ex
@@ -1,0 +1,94 @@
+defmodule RecordidWeb.DayActivityLive do
+  use RecordidWeb, :live_view
+  import RecordidWeb.ActivityComponents, only: [time_range: 1, time_duration: 1]
+
+  alias Recordid.Activities
+  alias RecordidWeb.ActivityLive.FormComponent
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"date" => date} = unsigned_params, _uri, socket) do
+    socket =
+      socket
+      |> assign(:date, date)
+      |> stream(:activities, list_activities(date))
+
+    {:noreply, apply_action(socket, socket.assigns.live_action, unsigned_params)}
+  end
+
+  defp list_activities(date) do
+    Activities.list_activities_for_date(date)
+  end
+
+  defp apply_action(socket, :new, _params) do
+    activity = Activities.new_activity()
+
+    socket
+    |> assign(:page_title, "New activity")
+    |> assign(:activity, activity)
+  end
+
+  defp apply_action(socket, :edit, %{"id" => id} = _params) do
+    activity = Activities.get_activity!(id)
+
+    socket
+    |> assign(:page_title, "Edit activity")
+    |> assign(:activity, activity)
+  end
+
+  defp apply_action(socket, :index, _params) do
+    socket
+    |> assign(:page_title, "Listing activities")
+    |> assign(:activity, nil)
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("start_activity", %{"current_time" => time} = _unsigned_params, socket) do
+    attrs = %{"time_started" => time, "date_started" => socket.assigns.date}
+
+    case Activities.create_activity(attrs) do
+      {:ok, _activity} ->
+        {:noreply,
+         socket
+         |> stream(:activities, list_activities(socket.assigns.date), reset: true)
+         |> put_flash(:info, "Activity created successfully")}
+
+      {:error, _cset} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Could not create activity")}
+    end
+  end
+
+  def handle_event("delete", %{"id" => activity_id} = params, socket) do
+    activity = Activities.get_activity!(activity_id)
+
+    case Activities.delete_activity(activity) do
+      {:ok, _activity} ->
+        {:noreply, push_patch(socket, ~p"/days/#{socket.assigns.date}")}
+
+      {:error, changeset} ->
+        {:noreply, push_patch(socket, ~p"/days/#{socket.assigns.date}")}
+    end
+  end
+
+  @impl true
+  def handle_info({FormComponent, {:saved, activity}}, socket) do
+    activities = list_activities(socket.assigns.date)
+    {:noreply, stream(socket, :activities, activities, reset: true)}
+  end
+
+  def handle_info({FormComponent, {:deleted_activity, activity}}, socket) do
+    activities = list_activities(socket.assigns.date)
+    {:noreply, stream(socket, :activities, activities, reset: true)}
+  end
+
+  def handle_info({FormComponent, {:delete_activity_failed, activity}}, socket) do
+    activities = list_activities(socket.assigns.date)
+    {:noreply, stream(socket, :activities, activities, reset: true)}
+  end
+end

--- a/lib/recordid_web/live/day_activity_live.html.heex
+++ b/lib/recordid_web/live/day_activity_live.html.heex
@@ -1,0 +1,54 @@
+<div class="flex justify-between content-center mb-2">
+  <h1 class="font-bold text-2xl"><%= @date %></h1>
+</div>
+
+<div class="flex gap-2">
+  <.link patch={~p"/days/#{@date}/activities/new"}>
+    <button
+      id="new-activity"
+      class="phx-submit-loading:opacity-75 rounded-2xl border border-blue-500 px-4 py-1 text-xs text-blue-500 hover:bg-blue-500 hover:text-white"
+    >
+      <.icon name="hero-plus-circle-solid" class="w-4 h-4" /> New
+    </button>
+  </.link>
+  <.link phx-click="start_activity" id="start-activity" }>
+    <button class="phx-submit-loading:opacity-75 rounded-2xl border border-blue-500 px-4 py-1 text-xs text-blue-500 hover:bg-blue-500 hover:text-white">
+      <.icon name="hero-clock-solid" class="w-4 h-4" /> Start
+    </button>
+  </.link>
+</div>
+
+<div class="mt-8">
+  <ul id="activities" phx-update="stream">
+    <li :for={{id, activity} <- @streams.activities} id={id} class="hover:bg-blue-100/50">
+      <.link patch={~p"/days/#{@date}/activities/#{activity}/edit"} class="group">
+        <div class="flex space-x-4 mb-4">
+          <div class="flex flex-col grow-0 shrink-0 basis-1/4">
+            <.time_range started_at={activity.time_started} finished_at={activity.time_finished} />
+            <.time_duration activity={activity} />
+          </div>
+          <div class="grow basis-3/4">
+            <%= activity.description %>
+          </div>
+        </div>
+      </.link>
+    </li>
+  </ul>
+</div>
+
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="activity-modal"
+  show
+  on_cancel={JS.patch(~p"/days/#{@date}")}
+>
+  <.live_component
+    module={RecordidWeb.ActivityLive.FormComponent}
+    id={@activity.id || :new}
+    title={@page_title}
+    action={@live_action}
+    activity={@activity}
+    date={@date}
+    patch={~p"/days/#{@date}"}
+  />
+</.modal>

--- a/lib/recordid_web/router.ex
+++ b/lib/recordid_web/router.ex
@@ -25,6 +25,12 @@ defmodule RecordidWeb.Router do
 
     live "/activities/:id", ActivityLive.Show, :show
     live "/activities/:id/show/edit", ActivityLive.Show, :edit
+
+    live "/today", TodayLive
+
+    live "/days/:date", DayActivityLive, :index
+    live "/days/:date/activities/new", DayActivityLive, :new
+    live "/days/:date/activities/:id/edit", DayActivityLive, :edit
   end
 
   # Other scopes may use custom stacks.

--- a/test/recordid/activities/activity_test.exs
+++ b/test/recordid/activities/activity_test.exs
@@ -1,5 +1,0 @@
-defmodule Recordid.Activities.ActivityTest do
-  use Recordid.DataCase, async: true
-
-  alias Recordid.Actvities.Activity
-end

--- a/test/recordid/activities/duration_test.exs
+++ b/test/recordid/activities/duration_test.exs
@@ -1,0 +1,198 @@
+defmodule Recordid.Activities.DurationTest do
+  use Recordid.DataCase, async: true
+
+  alias Recordid.Activities.Activity
+  alias Recordid.Activities.Duration
+
+  describe "from_activity/1" do
+    test "with sub-minute duration" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:01:00],
+        time_finished: ~T[00:01:59],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:ok, duration} = Duration.from_activity(activity)
+
+      assert duration.days == 0
+      assert duration.hours == 0
+      assert duration.minutes == 0
+    end
+
+    test "with minute duration" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:01:00],
+        time_finished: ~T[00:02:00],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:ok, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 1} = duration
+    end
+
+    test "with sub-hour duration" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:01],
+        time_finished: ~T[00:59:59],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:ok, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 59} = duration
+    end
+
+    test "with sub-day duration" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:00],
+        time_finished: ~T[23:59:59],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:ok, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 23, minutes: 59} = duration
+    end
+
+    test "with multi-day duration" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:00],
+        time_finished: ~T[23:59:59],
+        date_started: date,
+        date_finished: Date.add(date, 1)
+      }
+
+      {:ok, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 1, hours: 23, minutes: 59} = duration
+    end
+
+    test "without start and finish" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        date_started: date,
+        date_finished: date
+      }
+
+      {:error, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 0} = duration
+    end
+
+    test "without start" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_finished: ~T[23:59:59],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:error, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 0} = duration
+    end
+
+    test "without finish" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:00],
+        date_started: date,
+        date_finished: date
+      }
+
+      {:error, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 0} = duration
+    end
+
+    test "without date started" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:00],
+        time_finished: ~T[23:59:59],
+        date_finished: date
+      }
+
+      {:error, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 0} = duration
+    end
+
+    test "without date finished" do
+      date = Date.utc_today()
+
+      activity = %Activity{
+        description: "Test description",
+        time_started: ~T[00:00:00],
+        time_finished: ~T[23:59:59],
+        date_started: date
+      }
+
+      {:error, duration} = Duration.from_activity(activity)
+
+      assert %Duration{days: 0, hours: 0, minutes: 0} = duration
+    end
+  end
+
+  describe "to_string/1" do
+    test "days, hours, and minutes" do
+      duration = %Duration{days: 2, hours: 23, minutes: 59}
+
+      actual = Duration.to_string(duration)
+
+      assert "2d 23h 59m" == actual
+    end
+
+    test "hours and minutes" do
+      duration = %Duration{hours: 23, minutes: 59}
+
+      actual = Duration.to_string(duration)
+
+      assert "23h 59m" == actual
+    end
+
+    test "minutes" do
+      duration = %Duration{minutes: 59}
+
+      actual = Duration.to_string(duration)
+
+      assert "59m" == actual
+    end
+
+    test "empty duration" do
+      duration = %Duration{}
+
+      actual = Duration.to_string(duration)
+
+      assert "" == actual
+    end
+  end
+end

--- a/test/recordid/activities_test.exs
+++ b/test/recordid/activities_test.exs
@@ -25,6 +25,34 @@ defmodule Recordid.ActivitiesTest do
       assert Activities.list_activities() == [activity]
     end
 
+    test "list_activities_for_date/1 returns all activities for a given date" do
+      today = Date.utc_today()
+
+      for n <- 0..3 do
+        day = Date.add(today, n * -1)
+        for m <- 0..Enum.random(1..3) do
+          time_started = Time.from_iso8601!("0#{m}:#{n}#{m+1}:00")
+          activity_fixture(
+            date_started: day,
+            date_finished: day,
+            time_started: time_started,
+            time_finished: Time.add(time_started, m * Enum.random(0..9))
+          )
+        end
+      end
+
+      activities = Activities.list_activities_for_date(today)
+      for activity <- activities do
+        assert today == activity.date_started
+      end
+
+      two_days_ago = Date.add(today, -2)
+      activities = Activities.list_activities_for_date(two_days_ago)
+      for activity <- activities do
+        assert two_days_ago == activity.date_started
+      end
+    end
+
     test "get_activity!/1 returns the activity with given id" do
       activity = activity_fixture()
       assert Activities.get_activity!(activity.id) == activity

--- a/test/recordid_web/live/day_activity_live_test.exs
+++ b/test/recordid_web/live/day_activity_live_test.exs
@@ -1,0 +1,103 @@
+defmodule RecordidWeb.DayActivityLiveTest do
+  use RecordidWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  import Recordid.ActivitiesFixtures, only: [activity_fixture: 1]
+
+  test "loads all the activities for a given day", %{conn: conn} do
+    day = ~D[2023-07-17]
+
+    day_activities = create_activities_for_day(day, 2)
+
+    other_activities =
+      day
+      |> Date.add(-1)
+      |> create_activities_for_day(3)
+
+    {:ok, _live_view, html} = live(conn, ~p"/days/#{Date.to_string(day)}")
+
+    for activity <- day_activities do
+      assert html =~ activity.description
+    end
+
+    for activity <- other_activities do
+      refute html =~ activity.description
+    end
+  end
+
+  test "creating a new activity directly", %{conn: conn} do
+    day = ~D[2023-03-15]
+    description = "New test activity"
+
+    {:ok, live_view, _html} = live(conn, ~p"/days/#{Date.to_string(day)}/activities/new")
+
+    live_view
+    |> form("#activity-form", activity: %{"description" => description})
+    |> render_submit()
+
+    assert_patch(live_view, ~p"/days/#{Date.to_string(day)}")
+
+    html =
+      live_view
+      |> render()
+
+    assert html =~ "Activity created successfully"
+    assert html =~ description
+  end
+
+  test "editing an activity", %{conn: conn} do
+    day = ~D[2023-03-15]
+    new_description = "A new test activity"
+
+    activity =
+      activity_fixture(
+        description: "Test activity to edit",
+        time_started: ~T[00:01:00],
+        time_finished: Time.add(~T[00:01:00], 25, :minute),
+        date_started: day,
+        date_finished: day
+      )
+
+    {:ok, live_view, _html} =
+      live(conn, ~p"/days/#{Date.to_string(day)}/activities/#{activity.id}/edit")
+
+    live_view
+    |> form("#activity-form", activity: %{"description" => new_description})
+    |> render_submit()
+
+    assert_patch(live_view, ~p"/days/#{Date.to_string(day)}")
+
+    html =
+      live_view
+      |> render()
+
+    assert html =~ new_description
+  end
+
+  test "starting an activity", %{conn: conn} do
+    day = ~D[2023-03-15]
+
+    {:ok, live_view, html} = live(conn, ~p"/days/#{Date.to_string(day)}")
+
+    live_view
+    |> element("#start-activity")
+    |> render_click()
+
+    assert_patch(live_view, ~p"/days/#{Date.to_string(day)}")
+
+    html = live_view |> render()
+
+    assert html =~ ~r/[0-2]\d:[0-5]\d-/
+  end
+
+  defp create_activities_for_day(day, count \\ 0) do
+    for n <- 0..count do
+      activity_fixture(
+        description: "Test activity #{n} for day #{day}",
+        time_started: ~T[00:01:00],
+        time_finished: Time.add(~T[00:01:00], 25, :minute),
+        date_started: day,
+        date_finished: day
+      )
+    end
+  end
+end

--- a/test/support/fixtures/activities_fixtures.ex
+++ b/test/support/fixtures/activities_fixtures.ex
@@ -17,4 +17,25 @@ defmodule Recordid.ActivitiesFixtures do
 
     activity
   end
+
+  def full_activity_finished(:today) do
+    full_activity_finished(Date.utc_today())
+  end
+
+  def full_activity_finished(:yesterday) do
+    Date.utc_today()
+    |> Date.add(-1)
+    |> full_activity_finished()
+  end
+
+  def full_activity_finished(date) do
+    attrs = %{
+      date_started: date,
+      date_finished: date,
+      time_started: Time.utc_now(),
+      time_finished: Time.add(Time.utc_now(), 60*20),
+      description: "Test description #{Enum.random(0..10_000)}"
+    }
+    activity_fixture(attrs)
+  end
 end


### PR DESCRIPTION
The primary interface for interacting with activities is by day. The user wants to record what they are accomplishing throughout the day. This commit adds the live view and related code to support vieiwng and interacting with activites for a given day.