### PR TITLE
Provide a view listing days with activities

### DIFF
--- a/lib/recordid/activities.ex
+++ b/lib/recordid/activities.ex
@@ -24,6 +24,18 @@ defmodule Recordid.Activities do
     |> Repo.all()
   end
 
+  def list_days_with_activities(user = %User{}) do
+    query =
+      from(a in Activity,
+        where: not is_nil(a.date_started) and a.user_id == ^user.id,
+        select: %{date: a.date_started, activity_count: count(a.id)},
+        group_by: [a.date_started],
+        order_by: [desc: a.date_started]
+      )
+
+    Repo.all(query)
+  end
+
   @doc """
   Returns a list of activities for a given date sorted by start time descending.
   """

--- a/lib/recordid_web/live/day_activity_live.html.heex
+++ b/lib/recordid_web/live/day_activity_live.html.heex
@@ -1,5 +1,5 @@
 <div class="flex justify-between content-center mb-2">
-  <h1 class="font-bold text-2xl"><%= @date %></h1>
+  <h1 class="font-bold text-4xl"><%= @date %></h1>
 </div>
 
 <div class="flex gap-2">

--- a/lib/recordid_web/live/day_live.ex
+++ b/lib/recordid_web/live/day_live.ex
@@ -1,0 +1,21 @@
+defmodule RecordidWeb.DayLive do
+  use RecordidWeb, :live_view
+
+  alias Recordid.Activities
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(_params, _uri, %{assigns: %{current_user: current_user}} = socket) do
+    days = Activities.list_days_with_activities(current_user)
+
+    socket =
+      socket
+      |> assign(:days, days)
+      # TODO(lancejjohnson): Replace UTC today with time zone aware
+      |> assign(:today, Date.utc_today())
+
+    {:noreply, socket}
+  end
+end

--- a/lib/recordid_web/live/day_live.html.heex
+++ b/lib/recordid_web/live/day_live.html.heex
@@ -1,0 +1,35 @@
+<.header class="mb-12">
+  <h1 class="font-bold text-4xl">
+    Activity Days
+  </h1>
+  <:actions>
+    <.link navigate={~p"/days/#{Date.to_string(@today)}"}>
+      <.button>
+        Today
+      </.button>
+    </.link>
+  </:actions>
+</.header>
+<ul>
+  <li :for={day <- @days} id="days-list">
+    <.link navigate={~p"/days/#{Date.to_string(day[:date])}"}>
+      <div class="flex flex-col mb-4 p-4 border rounded-lg hover:bg-gray-200/50">
+        <div class="flex mb-8">
+          <h2 class="text-2xl font-semibold">
+            <%= Date.to_string(day[:date]) %>
+          </h2>
+        </div>
+        <div>
+          <div class="flex">
+            <div class="flex flex-col items-center">
+              <span class="text-xs uppercase font-semibold text-gray-300">Activities</span>
+              <span class="text-xl uppercase font-bold text-gray-600">
+                <%= day[:activity_count] %>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </.link>
+  </li>
+</ul>

--- a/lib/recordid_web/router.ex
+++ b/lib/recordid_web/router.ex
@@ -78,6 +78,7 @@ defmodule RecordidWeb.Router do
       live "/activities/:id", ActivityLive.Show, :show
       live "/activities/:id/show/edit", ActivityLive.Show, :edit
 
+      live "/days", DayLive, :index
       live "/days/:date", DayActivityLive, :index
       live "/days/:date/activities/new", DayActivityLive, :new
       live "/days/:date/activities/:id/edit", DayActivityLive, :edit

--- a/lib/recordid_web/user_auth.ex
+++ b/lib/recordid_web/user_auth.ex
@@ -223,5 +223,5 @@ defmodule RecordidWeb.UserAuth do
 
   defp maybe_store_return_to(conn), do: conn
 
-  defp signed_in_path(_conn), do: ~p"/"
+  defp signed_in_path(_conn), do: ~p"/days"
 end

--- a/test/recordid_web/controllers/user_session_controller_test.exs
+++ b/test/recordid_web/controllers/user_session_controller_test.exs
@@ -15,7 +15,7 @@ defmodule RecordidWeb.UserSessionControllerTest do
         })
 
       assert get_session(conn, :user_token)
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
 
       # Now do a logged in request and assert on the menu
       conn = get(conn, ~p"/")
@@ -36,7 +36,7 @@ defmodule RecordidWeb.UserSessionControllerTest do
         })
 
       assert conn.resp_cookies["_recordid_web_user_remember_me"]
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
     end
 
     test "logs the user in with return to", %{conn: conn, user: user} do
@@ -65,7 +65,7 @@ defmodule RecordidWeb.UserSessionControllerTest do
           }
         })
 
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "Account created successfully"
     end
 

--- a/test/recordid_web/live/day_live_test.exs
+++ b/test/recordid_web/live/day_live_test.exs
@@ -1,0 +1,38 @@
+defmodule RecordidWeb.Live.DayLiveTest do
+  use RecordidWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+  import Recordid.ActivitiesFixtures
+
+  setup :register_and_log_in_user
+
+  test "lists all of the days for which you have recordid activities", %{conn: conn, user: user} do
+    days = [~D[2023-03-15], ~D[2023-03-15], ~D[2023-01-01], ~D[2022-12-25]]
+
+    for day <- days do
+      create_activities(
+        user,
+        %{
+          date_started: day,
+          date_finished: day,
+          time_started: Time.utc_now(),
+          time_finished: Time.utc_now() |> Time.add(25, :minute),
+          description: "Test activity for user #{user.id} on day #{Date.to_string(day)}"
+        },
+        Enum.random(1..3)
+      )
+    end
+
+    {:ok, live_view, html} = live(conn, ~p"/days")
+
+    for day <- days do
+      assert html =~ Date.to_string(day)
+      assert has_element?(live_view, "a", Date.to_string(day))
+    end
+  end
+
+  test "provides access to the day activity view for today", %{conn: conn} do
+    {:ok, live_view, _html} = live(conn, ~p"/days")
+
+    assert has_element?(live_view, "a", "Today")
+  end
+end

--- a/test/recordid_web/live/user_forgot_password_live_test.exs
+++ b/test/recordid_web/live/user_forgot_password_live_test.exs
@@ -21,7 +21,7 @@ defmodule RecordidWeb.UserForgotPasswordLiveTest do
         conn
         |> log_in_user(user_fixture())
         |> live(~p"/users/reset_password")
-        |> follow_redirect(conn, ~p"/")
+        |> follow_redirect(conn, ~p"/days")
 
       assert {:ok, _conn} = result
     end

--- a/test/recordid_web/live/user_login_live_test.exs
+++ b/test/recordid_web/live/user_login_live_test.exs
@@ -18,7 +18,7 @@ defmodule RecordidWeb.UserLoginLiveTest do
         conn
         |> log_in_user(user_fixture())
         |> live(~p"/users/log_in")
-        |> follow_redirect(conn, "/")
+        |> follow_redirect(conn, "/days")
 
       assert {:ok, _conn} = result
     end
@@ -36,7 +36,7 @@ defmodule RecordidWeb.UserLoginLiveTest do
 
       conn = submit_form(form, conn)
 
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
     end
 
     test "redirects to login page with a flash error if there are no valid credentials", %{

--- a/test/recordid_web/live/user_registration_live_test.exs
+++ b/test/recordid_web/live/user_registration_live_test.exs
@@ -17,7 +17,7 @@ defmodule RecordidWeb.UserRegistrationLiveTest do
         conn
         |> log_in_user(user_fixture())
         |> live(~p"/users/register")
-        |> follow_redirect(conn, "/")
+        |> follow_redirect(conn, "/days")
 
       assert {:ok, _conn} = result
     end
@@ -45,7 +45,7 @@ defmodule RecordidWeb.UserRegistrationLiveTest do
       render_submit(form)
       conn = follow_trigger_action(form, conn)
 
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
 
       # Now do a logged in request and assert on the menu
       conn = get(conn, "/")

--- a/test/recordid_web/user_auth_test.exs
+++ b/test/recordid_web/user_auth_test.exs
@@ -22,7 +22,7 @@ defmodule RecordidWeb.UserAuthTest do
       conn = UserAuth.log_in_user(conn, user)
       assert token = get_session(conn, :user_token)
       assert get_session(conn, :live_socket_id) == "users_sessions:#{Base.url_encode64(token)}"
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
       assert Accounts.get_user_by_session_token(token)
     end
 
@@ -216,7 +216,7 @@ defmodule RecordidWeb.UserAuthTest do
     test "redirects if user is authenticated", %{conn: conn, user: user} do
       conn = conn |> assign(:current_user, user) |> UserAuth.redirect_if_user_is_authenticated([])
       assert conn.halted
-      assert redirected_to(conn) == ~p"/"
+      assert redirected_to(conn) == ~p"/days"
     end
 
     test "does not redirect if user is not authenticated", %{conn: conn} do

--- a/test/support/fixtures/activities_fixtures.ex
+++ b/test/support/fixtures/activities_fixtures.ex
@@ -7,6 +7,16 @@ defmodule Recordid.ActivitiesFixtures do
   alias Recordid.Accounts.User
   alias Recordid.AccountsFixtures
 
+  def create_activities(user, attrs \\ %{}, count \\ 1)
+
+  def create_activities(user, attrs, count) do
+    attrs = Map.put_new(attrs, :user_id, user.id)
+
+    for _ <- 1..count do
+      activity_fixture(attrs)
+    end
+  end
+
   @doc """
   Generate a activity.
   """


### PR DESCRIPTION
Provide a live view that lists all the days for which a user has activities recorded. This is the default view for the user after they log in to the application.